### PR TITLE
fixed bad params for list_portfolio_access

### DIFF
--- a/scripts/sync-catalog.py
+++ b/scripts/sync-catalog.py
@@ -229,7 +229,7 @@ def list_portfolios():
 
     while not done:
         if nextmarker:
-            portfolio_response = client.list_portfolios(nextmarker=nextmarker)
+            portfolio_response = client.list_portfolios(PageToken=nextmarker)
         else:
             portfolio_response = client.list_portfolios()
 
@@ -256,7 +256,7 @@ def list_products_for_portfolio(id):
 
     while not done:
         if nextmarker:
-            product_response = client.search_products_as_admin(nextmarker=nextmarker, PortfolioId=id)
+            product_response = client.search_products_as_admin(PageToken=nextmarker, PortfolioId=id)
         else:
             product_response = client.search_products_as_admin(PortfolioId=id)
 
@@ -391,7 +391,7 @@ def list_portfolio_shares(portfolioid):
 
     while not done:
         if nextmarker:
-            lst_portfolio_access = client.list_portfolio_access(nextmarker=nextmarker, PortfolioId=portfolioid)
+            lst_portfolio_access = client.list_portfolio_access(PageToken=nextmarker, PortfolioId=portfolioid)
         else:
             lst_portfolio_access = client.list_portfolio_access(PortfolioId=portfolioid)
 


### PR DESCRIPTION
*Issue #, if available:*
#4 

*Description of changes:*
Some instances of the list_portfolio_access and search_products methods incorrectly listed "nextmarker" as a parameter causing exceptions whenever product lists or portfolio access data was long enough to require pagination. This fix adds the correct parameter to these methods: "PageToken".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
